### PR TITLE
Implement pump thread and pump commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 
 .vscode/settings.json
+build
+test
+CMakeLists.txt

--- a/pump.cpp
+++ b/pump.cpp
@@ -41,10 +41,10 @@ int Pump::off() {
 int Pump::on() {
 
     try {
-	    digitalWrite(pin, HIGH);
+        digitalWrite(pin, HIGH);
         on_flag = 1;
         running_since = time(0);
-    }catch(...) {
+    } catch(...) {
         return -1;
     }
 return 0;
@@ -110,11 +110,11 @@ PumpOnTimed::PumpOnTimed(unsigned int pumpTime) : PumpCommand() {
      * as not running the pump.
      */
     if (pumpTime > 60) {
-        pump_time = 60;
+        pump_time = 3600;
     } else if (pumpTime <= 0) {
         // Not implemented, but should throw an error.
     } else {
-        pump_time = pumpTime;
+        pump_time = pumpTime * 60;
     }
     
 }

--- a/pump.cpp
+++ b/pump.cpp
@@ -174,7 +174,7 @@ void PumpManagementTask(PumpCommandQueue& command_queue, shared_ptr<Pump> pump, 
      * The exit signal is a pointer to a boolean that ends the task when
      * it is set to true. The task checks the command queue, executes 
      * tasks, and updates the pump twice per second. Thus pump times 
-     * should be precise to withing one second of the requests pumping 
+     * should be precise to within one second of the requested pumping 
      * time.
      */
     shared_ptr<PumpCommand> pump_command; 

--- a/pump.h
+++ b/pump.h
@@ -14,6 +14,38 @@
 
 using namespace std;
 
+// Pump allows for the control of a single pump. Allows for the pump to 
+// be turned on and off. The pump must be connected to one of the GPIO 
+// pins of the Raspberry Pi, and the pin number of this pin must be 
+// provided to the constructor following the wiringPi pin numbering 
+// scheme. Details of this pin numbering scheme can be found here:
+//
+//      projects.drogan.net/raspberry-pi/wiringpi/pins/ 
+//
+// Example:
+//      
+//      // Create a pump object to control a pump that is connected to 
+//      // wiringPi pin 0 (GPIO 17):
+//      Pump pump = Pump(0);
+//
+//      // Now set the pump to run for 30 seconds and turn it on:
+//      pump.set_run_time(30);
+//      pump.on();
+//
+//      // Now we must call the update() method regularly:
+//      while( ... ) {
+//          
+//          ...
+//          
+//          pump.update();
+//          
+//          // sleep for a bit (~500 ms)
+//
+//      }
+//
+// The pump will track the ammount of time has been running and turn 
+// itself off after the requested 30 seconds, as long as the update() 
+// method is called on it regularly.      
 class Pump {
     
     private:

--- a/pump.h
+++ b/pump.h
@@ -121,19 +121,19 @@ class PumpOnTimed : public PumpCommand {
 };
 
 
-// PumpCommmandQueue is intended to be a thread safe queue for sending 
-// commands to the pump when it is running in a separate thread.
+// PumpCommmandQueue is a thread safe queue for sending commands to the 
+// pump when it is running in a separate thread.
 //
 // Example:
 // 
-//      // Create a shared_ptr to the queue (this can be sent to the 
+//      // Create a queue (this can be sent, using std::ref, to the 
 //      // thread in which the pump is running.)
-//      std::shared_ptr<PumpCommandQueue> command_queue = std::make_shared<PumpCommandQueue>();
+//      PumpCommandQueue command_queue;
 //            
 //      // Create a PumpCommand and send it to the queue, for example, 
 //      // we can command the pump to turn off:
 //      std::shared_ptr<PumpCommand> command = std::make_shared<PumpOff>();
-//      command_queue->push(command);
+//      command_queue.push(command);
 class PumpCommandQueue {
     
     private:

--- a/pump.h
+++ b/pump.h
@@ -137,28 +137,20 @@ class PumpOnTimed : public PumpCommand {
 class PumpCommandQueue {
     
     private:
-        shared_ptr<mutex> mtx;
-        shared_ptr<condition_variable> cv;
+        mutex mtx;
+        condition_variable cv;
         queue <shared_ptr<PumpCommand>> commands;
 
     public:
-        PumpCommandQueue();
+        PumpCommandQueue() = default;
+        PumpCommandQueue(const PumpCommandQueue&) = delete; // This disables copying
+        PumpCommandQueue& operator=(const PumpCommandQueue&) = delete; // This disables assignment
         void push(shared_ptr<PumpCommand> command);
         shared_ptr<PumpCommand> pop();
         shared_ptr<PumpCommand> dequeue();
         bool is_empty();
 };
 
-class PumpManager {
-
-    private:
-        shared_ptr<PumpCommandQueue> command_queue;
-        shared_ptr<Pump> pump;
-
-    public:
-        PumpManager(shared_ptr<PumpCommandQueue> commandQueue, shared_ptr<Pump> pump_to_manage);
-        void task();
-        void cont_task(shared_ptr<bool> exit_signal);
-};
+void PumpManagementTask(PumpCommandQueue& command_queue, shared_ptr<Pump> pump, shared_ptr<bool> exit_signal);
 
 #endif // PUMP_H_

--- a/pump.h
+++ b/pump.h
@@ -1,15 +1,15 @@
 #ifndef PUMP_H_
 #define PUMP_H_
 
-#include <vector>
-#include <string>
-#include <sstream>
+#include <queue>
 #include <iostream>
-#include <vector>
-#include <string>
 #include <wiringPi.h>
+#include <chrono>
+#include <memory>
+#include <mutex>
 #include <thread>
 #include <chrono>
+#include <condition_variable>
 
 using namespace std;
 
@@ -17,12 +17,73 @@ class Pump {
     
     private:
         int pin;
+        bool on_flag = 0;
+        unsigned int running_since;
+        unsigned int time_to_run = 0;
+        bool is_on_timed();
+        unsigned int get_running_time();
+        bool has_reached_or_exceeded_time_to_run();
     
     public:
         Pump(int pumpPin);
         int off();
-        int on(int time);
-        int method(vector<string> values);
+        int on();
+        void set_run_time(unsigned int seconds_to_run);
+        bool is_on();
+        void update();
 };
 
+class PumpCommand {
+    public:
+        virtual ~PumpCommand() {};
+        virtual void execute(shared_ptr <Pump> pump) = 0;
+};
+
+class PumpOn : public PumpCommand {
+    public:
+        void execute(shared_ptr <Pump> pump) override;
+};
+
+class PumpOff : public PumpCommand {
+    public:
+        void execute(shared_ptr <Pump> pump) override;
+};
+
+class PumpOnTimed : public PumpCommand {
+    private:
+        unsigned int pump_time;
+
+    public:
+        PumpOnTimed(unsigned int pump_time);
+        void execute(shared_ptr <Pump> pump) override;
+};
+
+class PumpCommandQueue {
+    // PumpCommmandQueue is intended to be a thread safe queue for 
+    // sending commands from the querry handler to the pump. It is a 
+    // wrapper around a std::queue.
+    private:
+        shared_ptr<mutex> mtx;
+        shared_ptr<condition_variable> cv;
+        queue <shared_ptr<PumpCommand>> commands;
+
+    public:
+        PumpCommandQueue();
+        void push(shared_ptr<PumpCommand> command);
+        shared_ptr<PumpCommand> pop();
+        shared_ptr<PumpCommand> dequeue();
+        bool is_empty();
+};
+
+class PumpManager {
+
+    private:
+        shared_ptr<PumpCommandQueue> command_queue;
+        shared_ptr<Pump> pump;
+
+    public:
+        PumpManager(shared_ptr<PumpCommandQueue> commandQueue, shared_ptr<Pump> pump_to_manage);
+        void task();
+        void cont_task();
+};
 #endif // PUMP_H_

--- a/pump.h
+++ b/pump.h
@@ -59,10 +59,22 @@ class PumpOnTimed : public PumpCommand {
         void execute(shared_ptr <Pump> pump) override;
 };
 
+
+// PumpCommmandQueue is intended to be a thread safe queue for sending 
+// commands to the pump when it is running in a separate thread.
+//
+// Example:
+// 
+//      // Create a shared_ptr to the queue (this can be sent to the 
+//      // thread in which the pump is running.)
+//      std::shared_ptr<PumpCommandQueue> command_queue = std::make_shared<PumpCommandQueue>();
+//            
+//      // Create a PumpCommand and send it to the queue, for example, 
+//      // we can command the pump to turn off:
+//      std::shared_ptr<PumpCommand> command = std::make_shared<PumpOff>();
+//      command_queue->push(command);
 class PumpCommandQueue {
-    // PumpCommmandQueue is intended to be a thread safe queue for 
-    // sending commands from the querry handler to the pump. It is a 
-    // wrapper around a std::queue.
+    
     private:
         shared_ptr<mutex> mtx;
         shared_ptr<condition_variable> cv;

--- a/pump.h
+++ b/pump.h
@@ -34,6 +34,35 @@ class Pump {
         void update();
 };
 
+
+// PumpCommand follow a modification of the GOF command pattern for 
+// sending commands to the pump. Three commands are implemented, these 
+// are:
+//
+//      1) PumpOn() - Turns the pump on indefinitely.
+//      2) PumpOff() - Turns the pump off indefinitely.
+//      3) PumpOnTimed(unsigned int pump_time) - Turns the pump on for 
+//          the number of minutes specified by pump_time (minimum times 
+//          is 1 minute, maximum time is 60 minutes).
+//
+// Unlike the GOF command pattern, the pump on which to execute the 
+// command is not bound to the command when it is constructed. Instead, 
+// the pump is provided in the arguement to the execute command by the 
+// invoker.
+//
+// Example:
+//
+//      // Create a pump and then create a command to turn it on for 5 
+//      // minutes:
+//      std::shared_ptr<Pump> pump = std:make_shared<Pump>(0);
+//      PumpOnTimed command_on_five_mins = PumpOnTimed(5);
+//      
+//      // Now use the command to turn the pump on for five mins:
+//      command_on_five_mins.execute(pump);
+//
+// Remember: in the above example, in order to ensure the pump runs for 
+// 5 mins will require constant, regular calling of the pump's `update` 
+// method.
 class PumpCommand {
     public:
         virtual ~PumpCommand() {};

--- a/pump.h
+++ b/pump.h
@@ -10,6 +10,7 @@
 #include <thread>
 #include <chrono>
 #include <condition_variable>
+#include <ctime>
 
 using namespace std;
 
@@ -18,7 +19,7 @@ class Pump {
     private:
         int pin;
         bool on_flag = 0;
-        unsigned int running_since;
+        time_t running_since;
         unsigned int time_to_run = 0;
         bool is_on_timed();
         unsigned int get_running_time();
@@ -84,6 +85,7 @@ class PumpManager {
     public:
         PumpManager(shared_ptr<PumpCommandQueue> commandQueue, shared_ptr<Pump> pump_to_manage);
         void task();
-        void cont_task();
+        void cont_task(shared_ptr<bool> exit_signal);
 };
+
 #endif // PUMP_H_


### PR DESCRIPTION
Implements a command pattern for sending instructions to the pump through three classes: PumpOn, PumpOff, and PumpOnTimed. This means that the pump doesn't need to know about the structure of the messages that are sent from the client (e.g., "pump", "on", "2" etc.).

Also implements a separate thread for running and managing the pump using a function called "PumpManagementTask".

A thread safe queue has been added for sending the commands from the main thread (where the querry_handler is running) to the pump management thread.

Additional details are provided in comments and messages in the commit log.

Relates to issue #2 